### PR TITLE
Added message to '!play' and '!storypoints'

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ client.on("message", (message) => {
   }
 
   if (message.content.startsWith("!play")) {
-    if (Poker.isQuestionRunning) return;
+    if (Poker.isQuestionRunning) return message.channel.send("There is already a question in progress.");
 
     const question = message.content.split(" ").splice(1).join(" ");
 
@@ -55,7 +55,7 @@ client.on("message", (message) => {
   }
 
   if (message.content.startsWith("!storypoints")) {
-    if (!Poker.isQuestionRunning) return;
+    if (!Poker.isQuestionRunning) return message.channel.send("You are currently not answering a question.");
 
     const storypoints = message.content.split(" ")[1];
 


### PR DESCRIPTION
Messages have been added to both '!play' and '!storypoints' to let the user know why they can not continue.

!play - returns "There is already a question in progress."
!storypoints - returns "You are currently not answering a question"

closes Message why a command is not working #10